### PR TITLE
Tweaks

### DIFF
--- a/xmt_xhist/bin/xhist_report
+++ b/xmt_xhist/bin/xhist_report
@@ -114,7 +114,7 @@ for (my $i = $tailindex+1; $i != $tailindex; $i++)
     $linenum = $xhist_tbl[$i] & 0x00FF;
     $threadnum = $xhist_threadIds[$i];
 
-    next if ($opt{thread} != $threadnum); # skip if not the specified thread
+    next if ($opt{thread} != $threadnum) && $opt{thread} != 0; # skip if not the specified thread
     next if ($linenum <= 0);	# skip if this element of the table was never populated
     
     if ($opt{fmt} eq 'vim' ) 	# output as replayable vimscript output

--- a/xmt_xhist/bin/xhist_report
+++ b/xmt_xhist/bin/xhist_report
@@ -112,7 +112,7 @@ for (my $i = $tailindex+1; $i != $tailindex; $i++)
     $i = -1 if ($i >= $numstmts - 1); # wrap-around so next index is 0
     $filenum = $xhist_tbl[$i] >> 16;
     $linenum = $xhist_tbl[$i] & 0x00FF;
-    $threadnum = $threadIds[$i];
+    $threadnum = $xhist_threadIds[$i];
 
     next if ($opt{thread} != $threadnum); # skip if not the specified thread
     next if ($linenum <= 0);	# skip if this element of the table was never populated


### PR DESCRIPTION
Fix an incorrect variable name causing threadId to always be reported as 0, and show trace from all threads if no thread is specified or thread 0 is specified. Java threads appear to start at thread 1.